### PR TITLE
Bump version to 1.2.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "net.botwithus.xapi"
-version = "1.2.10"
+version = "1.2.11"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Release bump to publish merged fixes from #22 (item destruction), #23 (infernal lodge), and #24 (dialog shift) to Nexus.