### PR TITLE
ConfirmItemDestruction: fix the stale destroy confirm component id

### DIFF
--- a/src/main/java/net/botwithus/api/game/hud/ConfirmItemDestruction.java
+++ b/src/main/java/net/botwithus/api/game/hud/ConfirmItemDestruction.java
@@ -8,7 +8,7 @@ import net.botwithus.rs3.script.Execution;
 import net.botwithus.rs3.util.RandomGenerator;
 
 public class ConfirmItemDestruction {
-    public static final int NO_ID = 77529094, YES_ID = 77529096;
+    public static final int NO_ID = 77529093, YES_ID = 77529095;
 
     public static boolean isOpen() {
         return Interfaces.isOpen(1183);


### PR DESCRIPTION
## Problem

`ConfirmItemDestruction.YES_ID` is still the pre-update `1183:8` (`77529096`). Interface 1183 shifted by one component in game build `1786123071`, so the live confirm button is `1183:7` (`77529095`), sniffed from a real client click:

```
Interface Opened: 1183 0 0
[Original-Blocked]: DoAction(DIALOGUE, 0, -1, 77529095)
```

The helper clicks the wrong component, the prompt stays open, the item never leaves the backpack, and any branch gated on the item still being present loops forever. ArchWithUs reproduced this on `Founder's journal page` transcribes — the leaf re-fired every tick indefinitely.

## Fix

- `YES_ID`: `77529096` → `77529095`
- `NO_ID`: `77529094` → `77529093` (same one-component shift; unused in-tree, not separately sniffed)

## Note

`confirm()` still calls `Backpack.interact(name, 8)` with a hardcoded op index, which only lines up for items whose destroy op happens to sit at 8. Left alone here to keep the change to the reported bug — callers that need a different option should interact by option name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqmm17WXrwV6CTrU3jQv77